### PR TITLE
Fix typo in curry howard correspondence table

### DIFF
--- a/slides/tut/Type.html
+++ b/slides/tut/Type.html
@@ -462,7 +462,7 @@ class: center, middle
 |Unit         | 1         | ⊤ (true)              |
 |Either[A, B] | A + B     | A ∨ B (or)            |
 |(A, B)       | A * B     | A ∧ B (and)           |
-| A => B      | B ^ A     | B → A (implies)       |
+| A => B      | B ^ A     | A → B (implies)       |
 | Isomorphism | A == B    | A ⇔ B (equivalence)   |
 ]
 
@@ -476,7 +476,7 @@ class: center, middle
 |Unit         | 1         | ⊤     |
 |Either[A, B] | A + B     | A ∨ B |
 |(A, B)       | A * B     | A ∧ B |
-| A => B      | B ^ A     | B → A |
+| A => B      | B ^ A     | A → B |
 | Isomorphism | A == B    | A ⇔ B |
 ]
 


### PR DESCRIPTION
Function A => B should correspond to implication A -> B