### PR TITLE
replace small with big or large

### DIFF
--- a/slides/tut/Type.html
+++ b/slides/tut/Type.html
@@ -303,7 +303,7 @@ def halfPriceFirstItem(order: Order): Order = {
 
 
 ---
-# Type too small
+# Type too big
 
 ```tut:silent
 import java.util.Date


### PR DESCRIPTION
List.size should non negative int, so being int is too wide.

fifthMarch is not intended to indicate a year, so the accuracy provided by Date is excessive.