### PR TITLE
wording in TypeExercises

### DIFF
--- a/exercises/src/main/scala/exercises/types/TypeExercises.scala
+++ b/exercises/src/main/scala/exercises/types/TypeExercises.scala
@@ -192,7 +192,7 @@ object TypeExercises extends TypeToImpl {
 
 
   ////////////////////////
-  // 4. Parametrictity
+  // 4. Parametricity
   ////////////////////////
 
   // 4a. How many implementations exist for id, const (assume we are using scalazzi subset)
@@ -218,12 +218,12 @@ object TypeExercises extends TypeToImpl {
   // 4g. How would you test mapList to achieve a VIC of 1
 
 
-  // Further reading on parametrictity
+  // Further reading on parametricity
   // Counting type inhabitants (by Alexander Konovalov): https://alexknvl.com/posts/counting-type-inhabitants.html
 
 
   ////////////////////////
-  // 5. Logic
+  // 5. Algebra
   ////////////////////////
 
   // 5a. in basic algebra, a * 1 = 1 * a = a and a + 0 = 0 + a = a (we say that 1 is the unit of * and 0 is the unit of +).


### PR DESCRIPTION
Parametricity is misspelled twice.

I am suggesting section 5 to be renamed Algebra from Logic. While the slides point to equivalence of algebra and logic, to me the focus of the exercises in Section 5 are actually of algebraic nature. Is there any consideration to introduce another section that is more compelling about logic?