### PR TITLE
remove comment requesting to implement maxOption

### DIFF
--- a/exercises/src/main/scala/exercises/typeclass/TypeclassExercises.scala
+++ b/exercises/src/main/scala/exercises/typeclass/TypeclassExercises.scala
@@ -334,7 +334,7 @@ object TypeclassExercises extends TypeclassToImpl {
 
   // 5g. Implement an instance of Semigroup for Dual
   // such as combine(Dual(1), Dual(2)) == Dual(combine(2, 1))
-  // Use Dual to implement maxOption and lastOptionList
+  // Use Dual to implement lastOptionList
   implicit def dualSemigroup[A: Semigroup]: Semigroup[Dual[A]] = new Semigroup[Dual[A]] {
     def combine(x: Dual[A], y: Dual[A]): Dual[A] = ???
   }


### PR DESCRIPTION
there are no tests for this, neither is there a case class for Max and the assumption that Dual could be used to implement a solution seems to be wrong since the Dual used for first and last relies on order of elements whereas Min and Max do not care since it's a commutative operator. This means that technically Dual is not really a generic "dual" but a rather special purpose tool for working on first and last.

Indeed your solution of the semigroup for Dual makes that clear:
    `def combine(x: Dual[A], y: Dual[A]): Dual[A] = Dual(Semigroup[A].combine(y.getDual, x.getDual))`

If you happen to think of a more general purpose notion of Dual semigroup that could use some kind of external function (associate max outcome as "dual" of min and similarly for first/last), then we probably have good reason to ask for a Max exercise. Otherwise I think it's just too much of a duplication of Min with no particular insight and hence I am simply suggesting to delete that comment.